### PR TITLE
Update links to point to new location of repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Content of this repository is generated from OpenAPI specification of
 
 ## KubeVirt API References
 
-* [master](https://kubevirt-incubator.github.io/api-reference/master/index.html)
+* [master](https://kubevirt.github.io/api-reference/master/index.html)


### PR DESCRIPTION
The api-reference repo was moved from kubevirt-incubator to kubevirt
organization.